### PR TITLE
 Fix result text between 1 year and 1 year 3 months

### DIFF
--- a/src/components/calc/Result.js
+++ b/src/components/calc/Result.js
@@ -40,7 +40,7 @@ export default class Header extends Component {
                 }
 
                 if (restMonths === 1){
-                    resultText = ', ' + restMonths + ' MONTH';
+                    resultText += ', ' + restMonths + ' MONTH';
                 } else if (restMonths >= 2 && years <= 2) {
                     resultText += ', ' + restMonths + ' MONTHS';
                 }

--- a/src/components/calc/Result.js
+++ b/src/components/calc/Result.js
@@ -39,7 +39,9 @@ export default class Header extends Component {
                     resultText = years + ' YEARS';
                 }
 
-                if (restMonths >= 3 && years <= 2) {
+                if (restMonths === 1){
+                    resultText = ', ' + restMonths + ' MONTH';
+                } else if (restMonths >= 2 && years <= 2) {
                     resultText += ', ' + restMonths + ' MONTHS';
                 }
             } else if (daysUntil40 >= 30) { // months


### PR DESCRIPTION
The existing code causes resultText to jump from 1 year 3 months down to 1 year. This change allows it to reduce smoothly to 1 year 2 months, then 1 year 1 month.